### PR TITLE
Catch case where sendRawTransaction doesn't return correct error message due to failed sendRawPrivateTransaction

### DIFF
--- a/lib/enclave/generic.js
+++ b/lib/enclave/generic.js
@@ -21,7 +21,7 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
 
   // tls settings fot https connections
   if (ipcPath === undefined) {
-    const {protocol} = url.parse(privateEndpoint);
+    const { protocol } = url.parse(privateEndpoint);
 
     if (protocol === "https:") {
       if (tlsParams.key) {
@@ -85,6 +85,11 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
     };
 
     return rp(sendRawPrivateTransactionRequest).then(res => {
+      if (res.error !== undefined) {
+        throw new Error(
+          `eth_sendRawPrivateTransaction failed: ${res.error.message}`
+        );
+      }
       return retry(
         () => {
           return getTransactionReceipt(res.result);
@@ -102,7 +107,7 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
         method: "POST",
         uri: `${privateEndpoint}/storeraw`,
         json: true,
-        body: {payload, from},
+        body: { payload, from },
         key: clientKey,
         cert: clientCert,
         ca,
@@ -116,7 +121,7 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
         method: "POST",
         uri: `${privateEndpoint}/send`,
         json: true,
-        body: {payload, from, to},
+        body: { payload, from, to },
         key: clientKey,
         cert: clientCert,
         ca,
@@ -130,7 +135,7 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
         method: "POST",
         uri: `${privateEndpoint}/receive`,
         json: true,
-        body: {key, to},
+        body: { key, to },
         key: clientKey,
         cert: clientCert,
         ca,
@@ -144,7 +149,7 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
         method: "POST",
         uri: `${publicEndpoint}/delete`,
         json: true,
-        body: {key},
+        body: { key },
         key: clientKey,
         cert: clientCert,
         ca,


### PR DESCRIPTION
fixes #36, fixes https://github.com/ConsenSys/quorum/issues/690
Catch the scenario where `eth_sendRawPrivateTransaction` fails to create the transaction and returns a response like:
```
  jsonrpc: '2.0',
  id: '1',
  error: {
    code: -32000,
    message: '404 status: Recipient not found for key: 1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg='
  }
```
In this case the code needs to return the error message from the response, rather than attempting to read the (non existent) transaction receipt.