### PR TITLE
Removes empty string 'to' fields from example scripts, changes them t…

### DIFF
--- a/7nodes-test/deployContractViaHttp-externalSigningTemplate.js
+++ b/7nodes-test/deployContractViaHttp-externalSigningTemplate.js
@@ -100,7 +100,6 @@ rawTransactionManager
         const rawTransaction = {
           nonce: `0x${nonce.toString(16)}`,
           from: accAddress,
-          to: "",
           value: `0x${(0).toString(16)}`,
           gasLimit: `0x${(4300000).toString(16)}`,
           gasPrice: `0x${(0).toString(16)}`,
@@ -119,7 +118,7 @@ rawTransactionManager
 
         return rawTransactionManager
           .sendRawRequest(privateTxHex, [
-            "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc="
+            "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc="
           ])
           .then(console.log)
           .catch(console.log);

--- a/7nodes-test/deployContractViaHttp-pe.js
+++ b/7nodes-test/deployContractViaHttp-pe.js
@@ -90,13 +90,12 @@ web3.eth.getTransactionCount(`0x${accAddress}`).then(txCount => {
   const newTx = rawTransactionManager.sendRawTransaction({
     gasPrice: 0,
     gasLimit: 4300000,
-    to: "",
     value: 0,
     data: bytecodeWithInitParam,
     from: signAcct,
     isPrivate: true,
     privateFrom: "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=",
-    privateFor: ["oNspPPgszVUFw0qmGFfWwh1uxVUXgvBxleXORHj07g8="],
+    privateFor: ["QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc="],
     nonce: txCount,
     privacyFlag: 1
   });

--- a/7nodes-test/deployContractViaHttp.js
+++ b/7nodes-test/deployContractViaHttp.js
@@ -90,13 +90,12 @@ web3.eth.getTransactionCount(`0x${accAddress}`).then(txCount => {
   const newTx = rawTransactionManager.sendRawTransaction({
     gasPrice: 0,
     gasLimit: 4300000,
-    to: "",
     value: 0,
     data: bytecodeWithInitParam,
     from: signAcct,
     isPrivate: true,
     privateFrom: "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=",
-    privateFor: ["oNspPPgszVUFw0qmGFfWwh1uxVUXgvBxleXORHj07g8="],
+    privateFor: ["QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc="],
     nonce: txCount
   });
 

--- a/7nodes-test/deployContractViaIpc.js
+++ b/7nodes-test/deployContractViaIpc.js
@@ -76,7 +76,7 @@ const bytecodeWithInitParam = simpleContract
 const ipcPath = process.env.IPC_PATH;
 
 if (ipcPath == null) {
-  console.log("Please specify ipc path");
+  console.log("Please specify tessera ipc path");
   process.exit();
 }
 
@@ -88,13 +88,12 @@ web3.eth.getTransactionCount(`0x${accAddress}`).then(txCount => {
   const newTx = rawTransactionManager.sendRawTransactionViaSendAPI({
     gasPrice: 0,
     gasLimit: 4300000,
-    to: "",
     value: 0,
     data: bytecodeWithInitParam,
     from: signAcct,
     isPrivate: true,
     privateFrom: "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=",
-    privateFor: ["ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc="],
+    privateFor: ["QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc="],
     nonce: txCount
   });
 


### PR DESCRIPTION
…o use node2's public key

Looks like the new version of web3 doesn't like the empty string value for 'to' when sending a contract creation transaction. Updated the examples to just not include a 'to' field.

I also changed the public keys in the examples to use 7nodes Node 2 instead of Node 7 or 5 or whatever it was using. This makes it work better when using a (smaller) wizard-generated network.