### PR TITLE
addLearner added

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,11 @@ const extend = function (web3, apis) {
         params: 1
       },
       {
+        name: 'addLearner',
+        call: 'raft_addLearner',
+        params: 1
+      },
+      {
         name: 'getRole',
         call: 'raft_role',
         params: 0


### PR DESCRIPTION
Seems like there were no methods for raft.addLearner in this repo, I added for you :) 