### PR TITLE
Bumping underscore dependency for security reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ethereumjs-tx": "^2.1.1",
     "request-promise-native": "^1.0.7",
     "rlp": "^2.2.3",
-    "underscore": "^1.9.1",
+    "underscore": "^1.13.1",
     "utf8": "^3.0.0",
     "web3": "^1.3.0"
   },


### PR DESCRIPTION
CVE-2021-23358

- https://nvd.nist.gov/vuln/detail/CVE-2021-23358
- https://snyk.io/vuln/SNYK-JS-UNDERSCORE-1080984